### PR TITLE
Fix for notes containing slashes in title

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ async function main(outputDirectory) {
 
 	return Promise.all(
 		rows.map(({ title, text }) => {
-			const filename = `${ title }.md`.replace("/", "-")
+			const filename = `${ title.replace("/", "-") }.md`
 
 			return fs.writeFile(path.join(outputDirectory, filename), text, { encoding: `utf8` })
 		})

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ async function main(outputDirectory) {
 
 	return Promise.all(
 		rows.map(({ title, text }) => {
-			const filename = `${ title }.md`
+			const filename = `${ title }.md`.replace("/", "-")
 
 			return fs.writeFile(path.join(outputDirectory, filename), text, { encoding: `utf8` })
 		})


### PR DESCRIPTION
Hi, 

Thanks for a very neat script!

One problem I encounter is that if the title contains a "/" an error is thrown.
It happens because the title is handled as a path.

**To reproduce**
1. Create a new note with the title "something/something"
2. run the script

The following error is thrown
```
❯ backup-bear-notes ~/Backup/Bear
/usr/local/lib/node_modules/backup-bear-notes/index.js:22
		throw err
		^

Error: ENOENT: no such file or directory, open '/Users/name/Backup/Bear/something/something'
```

This is a quick fix I use.